### PR TITLE
[AWN-63253] Ensure tcp_init_flags are initialized

### DIFF
--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -744,10 +744,12 @@ static TcpSession *StreamTcpNewSession (Packet *p, int id)
             ssn->client.tcp_flags = p->tcph ? p->tcph->th_flags : 0;
             ssn->client.tcp_init_flags = p->tcph->th_flags;
             ssn->server.tcp_flags = 0;
+            ssn->server.tcp_init_flags = 0;
         } else if (PKT_IS_TOCLIENT(p)) {
             ssn->server.tcp_flags = p->tcph ? p->tcph->th_flags : 0;
             ssn->server.tcp_init_flags = p->tcph->th_flags;
             ssn->client.tcp_flags = 0;
+            ssn->client.tcp_init_flags = 0;
         }
     }
 


### PR DESCRIPTION
The tcp_init_flags_* params are part of a TcpSession object which is allocated out of a pool which is
initially cleared to 0.
However, if a TcpSession is released, and then
reallocated, then it's assumed to be lazily
initialized.
In this case, however, the flags corresponding
to the opposite direction of the SYN packet were
not cleared to 0, which meant they contained the
previous/stale flags from the last use.
