### PR TITLE
SSC-1883 update tcp_init_flags if 1st packet arrives after 2nd packet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.rules
 *.pcap
 *.pcapng
+*.so
+*.so.[0-9]*
 /suricata.yaml
 Makefile
 .deps/
@@ -25,8 +27,11 @@ config.log
 config.status
 config.sub
 configure
+debian/
 depcomp
 doc/userguide/suricata.1
+ebpf/*.bpf
+ebpf/test
 etc/suricata.logrotate
 etc/suricata.service
 install-sh


### PR DESCRIPTION
In a TCP flow, suricata may see the 2nd packet from the client or
server before the 1st packet. This change handles this case, and updates
the `tcp_init_flags` field for the corresponding flow direction(s).

If the 1st packet in either directions is seen late, ensure that the
`STREAMTCP_FLAG_MIDSTREAM` flag is cleared if it no longer applies.

Also updated .gitignore to ignore some build artifacts

Testing:
- verified that an non-midstream flow observation is generated if the
  1st packets from the client and server aren't seen by suricata until
  after the 2nd packets. This was done by creating a custom pcap file
  using `editcap` and `mergecap`