### PR TITLE
[AWN-1030747] Improve suricata logging

### DIFF
--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -572,7 +572,7 @@ static void UnixCommandRun(UnixCommand * this, UnixClient *client)
         do {
             if (ret <= 0) {
                 if (ret == 0) {
-                    SCLogInfo("Unix socket: lost connection with client");
+                    SCLogDebug("Unix socket: lost connection with client");
                 } else {
                     SCLogInfo("Unix socket: error on recv() from client: %s",
                             strerror(errno));
@@ -603,7 +603,7 @@ static void UnixCommandRun(UnixCommand * this, UnixClient *client)
                     if (ret == -1) {
                         /* Signal was caught: just ignore it */
                         if (errno != EINTR) {
-                            SCLogInfo("Unix socket: lost connection with client");
+                            SCLogDebug("Unix socket: lost connection with client");
                             UnixCommandClose(this, client->fd);
                             return;
                         }


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ ] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [ ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
Suricata currently logging following info messages that need to be improved. 
1/10/2024 -- 13:41:21 - <Notice> - Suricata Main Loop Started
1/10/2024 -- 13:42:19 - <Info> - Unix socket: lost connection with client
1/10/2024 -- 13:43:19 - <Info> - Unix socket: lost connection with client
1/10/2024 -- 13:44:19 - <Info> - Unix socket: lost connection with client
1/10/2024 -- 13:45:19 - <Info> - Unix socket: lost connection with client

These logs will be surpressed

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
