### PR TITLE
[SSC-756] Add Suricata config to conffiles

### DIFF
--- a/debian/conffiles
+++ b/debian/conffiles
@@ -1,0 +1,1 @@
+/opt/suricata6/etc/suricata.yaml


### PR DESCRIPTION
Add `/opt/suricata6/etc/suricata.yaml` to Debian `conffiles` to mark it as a configuration file. This should prevent the package installation from overwriting the file if it already exists on the system (which was presumably generated by `rtk_suricataconfig.service`).

Testing:
* Build locally via `pack all cell/rtkbox/suricata6-xdp`
* Install package on my vSensor
```
vagrant@rtk-EC24F00172895DA:~$ date
Wed Nov 13 17:49:44 UTC 2024
vagrant@rtk-EC24F00172895DA:~$ ls -l /opt/suricata6/etc/suricata.yaml
-rw-rw-rw- 1 root root 12199 Nov 13 17:47 /opt/suricata6/etc/suricata.yaml
vagrant@rtk-EC24F00172895DA:~$ sha256sum /opt/suricata6/etc/suricata.yaml
7017b57cce04d4a6c44254d39f5dc948fdb2bcde0bde250bd2735ac0a9519961  /opt/suricata6/etc/suricata.yaml

vagrant@rtk-EC24F00172895DA:~$ sudo dpkg -i suricata6-xdp_6.0.18-awn1.27.999999_amd64.deb
(Reading database ... 86604 files and directories currently installed.)
Preparing to unpack suricata6-xdp_6.0.18-awn1.27.999999_amd64.deb ...
Unpacking suricata6-xdp (6.0.18-awn1.27.999999) over (6.0.18-awn1.26.126) ...
Setting up suricata6-xdp (6.0.18-awn1.27.999999) ...

Configuration file '/opt/suricata6/etc/suricata.yaml'
 ==> File on system created by you or by a script.
 ==> File also in package provided by package maintainer.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** suricata.yaml (Y/I/N/O/D/Z) [default=N] ?
Processing triggers for libc-bin (2.31-0ubuntu9.12) ...

vagrant@rtk-EC24F00172895DA:~$ ls -l /opt/suricata6/etc/suricata.yaml
-rw-rw-rw- 1 root root 12199 Nov 13 17:47 /opt/suricata6/etc/suricata.yaml
vagrant@rtk-EC24F00172895DA:~$ sha256sum /opt/suricata6/etc/suricata.yaml
7017b57cce04d4a6c44254d39f5dc948fdb2bcde0bde250bd2735ac0a9519961  /opt/suricata6/etc/suricata.yaml
```