### PR TITLE
[SSC-395] XDP filter for bypassed traffic

### DIFF
--- a/ebpf/Makefile.am
+++ b/ebpf/Makefile.am
@@ -12,6 +12,8 @@ BPF_TARGETS += bypass_filter.bpf
 BPF_TARGETS += xdp_filter.bpf
 BPF_TARGETS += xdp_lb.bpf
 BPF_TARGETS += xdp_lb_ew.bpf
+BPF_TARGETS += xdp_lb_ew_stream.bpf
+BPF_TARGETS += xdp_lb_stream.bpf
 BPF_TARGETS += xdp_ew.bpf
 BPF_TARGETS += vlan_filter.bpf
 

--- a/ebpf/build-xdp.sh
+++ b/ebpf/build-xdp.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+
+# A simple script to speed up build/test/debug iterations for XDP stuff.
+
+if [ "$#" -lt 1 ]; then
+  echo "USAGE: build-xdp.sh <name-of-source-file>"
+  exit 1
+fi
+
+docker exec suricata-dev \
+  bash -c "cd /workspaces/suricata-awn/ebpf && clang-10 -Wall -Iinclude -O2 \
+      -I/usr/include/x86_64-linux-gnu/ \
+      -D__KERNEL__ -D__ASM_SYSREG_H \
+      -target bpf -S -emit-llvm $1.c -o $1.ll \
+    && llc-10 -march=bpf -filetype=obj $1.ll -o $1.bpf \
+    && rm -f $1.ll"
+
+if [ $? -ne 0 ]; then
+  echo "Build failed. Make sure your BoB container is running. Start it using:"
+  echo "  pack docker run --name suricata-dev --container-user vagrant  cell.rtkbox.bob-debian16"
+  exit 1
+fi
+
+set -e
+
+if [ -z ${RTK_SENSOR_HOSTNAME} ]; then
+  echo "RTK_SENSOR_HOSTNAME is not set. Skipping scp."
+  exit 0
+else
+  echo "Copying $1.bpf to $RTK_SENSOR_HOSTNAME..."
+  scp -F $RTK_BUILD_ROOT/etc/ssh_config ./$1.bpf $RTK_SENSOR_HOSTNAME:~/ebpf
+fi
+
+echo "Restarting Suricata on $RTK_SENSOR_HOSTNAME..."
+ssh -F $RTK_BUILD_ROOT/etc/ssh_config vagrant@$RTK_SENSOR_HOSTNAME -t \
+  "sudo cp /home/vagrant/ebpf/$1.bpf /opt/suricata6/ebpf && \
+  sudo systemctl restart suricata6.service"
+
+echo "Suricata restarted. Tail /var/log/suricata.log to seen when XDP has initialized."
+echo "Example: \"Successfully loaded eBPF file '/opt/suricata6/ebpf/xdp_stream_filter.bpf' on 'lan0'\""

--- a/ebpf/build-xdp.sh
+++ b/ebpf/build-xdp.sh
@@ -2,18 +2,43 @@
 
 # A simple script to speed up build/test/debug iterations for XDP stuff.
 
-if [ "$#" -ne 1 ]; then
-  echo "USAGE: build-xdp.sh <name-of-source-file>"
+if [ "$#" -lt 1 ]; then
+  echo "USAGE: build-xdp.sh [-d|--debug] <name-of-source-file>"
   exit 1
+fi
+
+DEBUG_FLAGS=()
+
+SOURCE_FILE=()
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -d|--debug)
+      DEBUG_FLAGS="-g"
+      shift # past argument
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    *)
+      SOURCE_FILE+=("$1") # save positional arg
+      shift # past argument
+      ;;
+  esac
+done
+
+if [ ! -z "$DEBUG_FLAGS" ]; then
+  echo "Debug info enabled. Use \"llvm-objdump -S $SOURCE_FILE.bpf\" to see annotated assembly listing."
 fi
 
 docker exec suricata-dev \
   bash -c "cd /workspaces/suricata-awn/ebpf && clang-10 -Wall -Iinclude -O2 \
       -I/usr/include/x86_64-linux-gnu/ \
       -D__KERNEL__ -D__ASM_SYSREG_H \
-      -target bpf -S -emit-llvm $1.c -o $1.ll \
-    && llc-10 -march=bpf -filetype=obj $1.ll -o $1.bpf \
-    && rm -f $1.ll"
+      -target bpf -S $DEBUG_FLAGS -emit-llvm $SOURCE_FILE.c -o $SOURCE_FILE.ll \
+    && llc-10 -march=bpf -filetype=obj $SOURCE_FILE.ll -o $SOURCE_FILE.bpf \
+    && rm -f $SOURCE_FILE.ll"
 
 if [ $? -ne 0 ]; then
   echo "Build failed. Make sure your BoB container is running. Start it using:"
@@ -28,12 +53,12 @@ if [ -z ${RTK_SENSOR_HOSTNAME} ]; then
   exit 0
 fi
 
-echo "Copying $1.bpf to $RTK_SENSOR_HOSTNAME..."
-scp -F $RTK_BUILD_ROOT/etc/ssh_config ./$1.bpf $RTK_SENSOR_HOSTNAME:~/ebpf
+echo "Copying $SOURCE_FILE.bpf to $RTK_SENSOR_HOSTNAME..."
+scp -F $RTK_BUILD_ROOT/etc/ssh_config ./$SOURCE_FILE.bpf $RTK_SENSOR_HOSTNAME:~/ebpf
 
 echo "Restarting Suricata on $RTK_SENSOR_HOSTNAME..."
 ssh -F $RTK_BUILD_ROOT/etc/ssh_config vagrant@$RTK_SENSOR_HOSTNAME -t \
-  "sudo cp /home/vagrant/ebpf/$1.bpf /opt/suricata6/ebpf && \
+  "sudo cp /home/vagrant/ebpf/$SOURCE_FILE.bpf /opt/suricata6/ebpf && \
   sudo systemctl restart suricata6.service"
 
 echo "Suricata restarted. Tail /var/log/suricata.log to seen when XDP has initialized."

--- a/ebpf/build-xdp.sh
+++ b/ebpf/build-xdp.sh
@@ -2,7 +2,7 @@
 
 # A simple script to speed up build/test/debug iterations for XDP stuff.
 
-if [ "$#" -lt 1 ]; then
+if [ "$#" -ne 1 ]; then
   echo "USAGE: build-xdp.sh <name-of-source-file>"
   exit 1
 fi
@@ -26,10 +26,10 @@ set -e
 if [ -z ${RTK_SENSOR_HOSTNAME} ]; then
   echo "RTK_SENSOR_HOSTNAME is not set. Skipping scp."
   exit 0
-else
-  echo "Copying $1.bpf to $RTK_SENSOR_HOSTNAME..."
-  scp -F $RTK_BUILD_ROOT/etc/ssh_config ./$1.bpf $RTK_SENSOR_HOSTNAME:~/ebpf
 fi
+
+echo "Copying $1.bpf to $RTK_SENSOR_HOSTNAME..."
+scp -F $RTK_BUILD_ROOT/etc/ssh_config ./$1.bpf $RTK_SENSOR_HOSTNAME:~/ebpf
 
 echo "Restarting Suricata on $RTK_SENSOR_HOSTNAME..."
 ssh -F $RTK_BUILD_ROOT/etc/ssh_config vagrant@$RTK_SENSOR_HOSTNAME -t \

--- a/ebpf/test/test_framework.h
+++ b/ebpf/test/test_framework.h
@@ -1,6 +1,13 @@
 #ifndef __EBPF_TEST_FRAMEWORK__
 #define __EBPF_TEST_FRAMEWORK__
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdarg.h>
+
 /**
  * This file defines a fairly light unit testing framework and some tests, meant to allow
  * some degree of sanity checking to be done on an XDP program.

--- a/ebpf/test/xdp_lb.test.c
+++ b/ebpf/test/xdp_lb.test.c
@@ -227,6 +227,7 @@ void test_non_ip_packet(struct xdp_md* ctx) {
 
 int main() {
 	setup_mocks();
+	bpf_map_lookup_elem = bpf_map_lookup_elem_lb_mock;
 
 	// And our fake 32-bit addressable environment...
 	struct xdp_md ctx;

--- a/ebpf/test/xdp_stream.test.c
+++ b/ebpf/test/xdp_stream.test.c
@@ -1,5 +1,5 @@
 #include "test_framework.h"
-#define DEBUG 1
+//#define DEBUG 1
 #include "../xdp_lb_stream.c"
 #include "test_mocks.h"
 
@@ -209,6 +209,15 @@ void test_ipv6(struct xdp_md* ctx) {
   bpf_map_lookup_elem = bpf_map_lookup_elem_stream_mock_v4;
 }
 
+void test_debug_not_defined(struct xdp_md* ctx) {
+	// Ensure that the DEBUG macro is not defined in production
+#ifdef DEBUG
+	#if DEBUG != 0
+		assert(0);
+	#endif
+#endif
+}
+
 int main() {
   setup_mocks();
   bpf_map_lookup_elem = bpf_map_lookup_elem_stream_mock_v4;
@@ -222,6 +231,7 @@ int main() {
   TEST(IEEE8021ah_packet_vlan);
   TEST(no_match);
   TEST(ipv6);
+  TEST(debug_not_defined);
 
   return 0;
 }

--- a/ebpf/test/xdp_stream.test.c
+++ b/ebpf/test/xdp_stream.test.c
@@ -3,6 +3,7 @@
 #include "../xdp_lb_stream.c"
 #include "test_mocks.h"
 
+#define ntohs(x) __constant_htons(x)
 
 void test_ipv4_match(struct xdp_md* ctx) {
   char packet[] = 

--- a/ebpf/test/xdp_stream.test.c
+++ b/ebpf/test/xdp_stream.test.c
@@ -1,0 +1,227 @@
+#include "test_framework.h"
+#define DEBUG 1
+#include "../xdp_lb_stream.c"
+#include "test_mocks.h"
+
+
+void test_ipv4_match(struct xdp_md* ctx) {
+  char packet[] = 
+    "\x0\x50\x56\x80\x83\xd8\x0\x50\x56\x80\xdf\x93\x8\x0\x45\x0\x0\x84\xf7\x78"
+    "\x40\x0\x40\x6\x1f\xd4\xa\x8\x7\xb5\xa\x8\x7\x63\xb4\xa9\x0\x50\x29\x8b\xe3"
+    "\x91\x28\xe9\x5e\x9b\x80\x18\x1\xf6\x4d\x3b\x0\x0\x1\x1\x8\xa\x10\x9d\xe4"
+    "\x9a\x99\x4e\x3f\x1d\x47\x45\x54\x20\x2f\x50\x44\x46\x31\x30\x4d\x42\x20\x48"
+    "\x54\x54\x50\x2f\x31\x2e\x31\xd\xa\x48\x6f\x73\x74\x3a\x20\x31\x30\x2e\x38"
+    "\x2e\x37\x2e\x39\x39\xd\xa\x55\x73\x65\x72\x2d\x41\x67\x65\x6e\x74\x3a\x20"
+    "\x63\x75\x72\x6c\x2f\x37\x2e\x36\x38\x2e\x30\xd\xa\x41\x63\x63\x65\x70\x74"
+    "\x3a\x20\x2a\x2f\x2a\xd\xa\xd\xa";
+
+  CTX_SET(ctx, packet);
+
+  // Pointer value doesn't matter - just has to be non-NULL for a match
+  struct pair bpf_ret_value = {0, 0}; 
+  g_stream_map_lookup_value = &bpf_ret_value;
+
+  // This will contain the key that the filter tried to look up
+  struct flowv4_keys *key = &g_stream_map_v4_lookup_keys;
+
+  int result = xdp_loadfilter(ctx);
+  assert(result == XDP_DROP);
+
+  // Value from the pcap above. They'll be in little-endian in the key.
+  assert(key->ip_proto == 1);
+  assert(key->src == 0xb507080a);
+  assert(key->dst == 0x6307080a);
+  assert(key->port16[0] == 0xa9b4);
+  assert(key->port16[1] == 0x5000); // dest port: 80
+  assert(key->vlan0 == 0);
+  assert(key->vlan1 == 0);
+}
+
+void test_gre_match(struct xdp_md* ctx) {
+  // Packet borrowed from xdp_lb.test.c
+  // GRE packet from a capture, loaded into wireshark, and then "copy as escaped string"
+	char packet[] =
+		// Outer eth header
+		"\x00\x90\x0b\xa9\x49\x55\x00\x50\x56\x63\xf2\x58\x08\x00"
+		// Outer IP header
+		// src 192.29.36.175
+		// dest 172.29.35.160
+		"\x45\x00\x00\x98\xd1\x3d\x00\x00\x40\x2f\x07\x7a\xac\x1d\x24\xaf\xac\x1d\x24\x96"
+		// GRE
+		"\x10\x00\x88\xbe\x39\x8b\xdf\x97"
+		// ERSPAN
+		"\x10\x00\x00\x00\x00\x00\x00\x01"
+		// Inner eth header
+		"\x00\x50\x56\x94\x2d\x12\x00\x50\x56\x0b\x07\xf0\x08\x00"
+		// Inner IP header
+    // src0.0.1.16
+    // dest 165.225.33.253
+		"\x45\x00\x00\x66\x89\xf3\x40\x00\x40\x06\xdd\xb0\x0a\x00\x01\x10\xa5\xe1\x21\xfd"
+		// TCP header
+		"\xc4\x46\x01\xbb\xb6\x93\xef\x9f\x47\x24\xb2\x97"
+		"\x80\x18\x07\xfd\x74\xa5\x00\x00\x01\x01\x08\x0a\x65\xda\x08\x7e"
+		"\x4a\x02\xda\x1b"
+		// Layer 5...
+		"\x17\x03\x03\x00\x2d\x05\x74\xce\xee\x5f\xd7\xf9"
+		"\x0e\x52\xad\xd4\xf6\x5d\x51\x44\x7b\x41\x76\x4e\x61\x0b\x31\xaa"
+		"\x6b\x35\x01\x67\xae\x2c\x52\xf8\x42\x51\x25\xe4\x13\x95\x3a\x25"
+		"\x68\x25\xfe\x47\x9a\x2d";
+
+  CTX_SET(ctx, packet);
+
+  struct pair bpf_ret_value = {0, 0}; 
+  g_stream_map_lookup_value = &bpf_ret_value;
+
+  struct flowv4_keys *key = &g_stream_map_v4_lookup_keys;
+
+  int result = xdp_loadfilter(ctx);
+  assert(result == XDP_DROP);
+
+  //DPRINTF("key->ip_proto: %d, key->src: %x, key->dst: %x, key->port16[0]: %x, key->port16[1]: %x, key->vlan0: %d, key->vlan1: %d\n",
+  //        key->ip_proto, key->src, key->dst, key->port16[0], key->port16[1], key->vlan0, key->vlan1);
+
+  // little-endian
+  assert(key->ip_proto == 1);
+  assert(key->src == 0x1001000a);
+  assert(key->dst == 0xfd21e1a5);
+  assert(key->port16[0] == 0x46c4);
+  assert(key->port16[1] == 0xbb01); // dest port: 443
+  assert(key->vlan0 == 0);
+  assert(key->vlan1 == 0);
+}
+
+void test_IEEE8021ah_packet_vlan(struct xdp_md* ctx) {
+  // Example packet data in hex format (borrowed from xdp_lb.test.c)
+  char packet[] =
+  // ether header, next header == 8100
+  "\x02\x10\x00\xff\xff\xf0\x00\x17\x20\x05\x90\x87\x81\x00"
+  // vlan header, next header == 0x88e7
+  "\x0f\xd3\x88\xe7" // vlan == d30f & 0x0fff == 30f
+  // Provider backbone bridge (802.1ah), next header == 0x8100
+  "\x00\x00\x2d\x50\xb4\x0c\x25\xe0\x40\x10\xac\x1f\x6b\xb3\x4e\x91\x81\x00"
+  // vlan header, next header == 0x0800
+  "\x06\x40\x08\x00" // vlan == 4006 & 0x0fff == 6
+  // IPV4 header
+  //  Src IP == 10.96.16.7 (internal)
+  //  Dst IP == 10.16.98.31 (internal)
+  "\x45\x00\x00\x28\xa9\x0f\x40\x00\xff\x06\x4c\x2a\x0a\x60\x10\x07\x0a\x10\x62\x1f"
+  // TCP header and payload
+  "\x61\x6e\x0a\x26\x6d\x56\xbb\xc5\x0d\xa3\x02\x5a\x50\x10\x02\x02\x82\x8f\x00\x00\x00\x00\x00\x00\x00\x00";
+
+  CTX_SET(ctx, packet);
+
+  struct pair bpf_ret_value = {0, 0}; 
+  g_stream_map_lookup_value = &bpf_ret_value;
+
+  struct flowv4_keys *key = &g_stream_map_v4_lookup_keys;
+
+  int result = xdp_loadfilter(ctx);
+  assert(result == XDP_DROP);
+
+  assert(key->ip_proto == 1);
+  assert(key->src == 0x0710600a);
+  assert(key->dst == 0x1f62100a);
+  assert(key->port16[0] == 0x6e61);
+  assert(key->port16[1] == 0x260a);
+  assert(key->vlan0 == 0x30f);
+  assert(key->vlan1 == 6);
+
+  //DPRINTF("key->ip_proto: %d, key->src: %x, key->dst: %x, key->port16[0]: %x, key->port16[1]: %x, key->vlan0: %x, key->vlan1: %x\n",
+  //  key->ip_proto, key->src, key->dst, key->port16[0], key->port16[1], key->vlan0, key->vlan1);
+}
+
+void test_no_match(struct xdp_md* ctx) {
+  char packet[] = 
+    "\x0\x50\x56\x80\x83\xd8\x0\x50\x56\x80\xdf\x93\x8\x0\x45\x0\x0\x84\xf7\x78"
+    "\x40\x0\x40\x6\x1f\xd4\xa\x8\x7\xb5\xa\x8\x7\x63\xb4\xa9\x0\x50\x29\x8b\xe3"
+    "\x91\x28\xe9\x5e\x9b\x80\x18\x1\xf6\x4d\x3b\x0\x0\x1\x1\x8\xa\x10\x9d\xe4"
+    "\x9a\x99\x4e\x3f\x1d\x47\x45\x54\x20\x2f\x50\x44\x46\x31\x30\x4d\x42\x20\x48"
+    "\x54\x54\x50\x2f\x31\x2e\x31\xd\xa\x48\x6f\x73\x74\x3a\x20\x31\x30\x2e\x38"
+    "\x2e\x37\x2e\x39\x39\xd\xa\x55\x73\x65\x72\x2d\x41\x67\x65\x6e\x74\x3a\x20"
+    "\x63\x75\x72\x6c\x2f\x37\x2e\x36\x38\x2e\x30\xd\xa\x41\x63\x63\x65\x70\x74"
+    "\x3a\x20\x2a\x2f\x2a\xd\xa\xd\xa";
+
+  CTX_SET(ctx, packet);
+
+  // make bpf_map_lookup_elem return NULL
+  g_stream_map_lookup_value = NULL;
+
+  // This will contain the key that the filter tried to look up
+  struct flowv4_keys *key = &g_stream_map_v4_lookup_keys;
+
+  int result = xdp_loadfilter(ctx);
+  assert(result == XDP_PASS);
+
+  // Key has been verified in test_ipv4_match (packet is the same)
+}
+
+void test_ipv6(struct xdp_md* ctx) {
+  char packet[] =
+  // Ethernet header
+	"\x33\x33\x00\x01\x00\x02\x00\x22\xfb\x12\xda\xe8\x86\xdd"
+  // Ipv6 header
+  "\x60\x00\x00\x00\x00\x61\x11\x01"
+  // Source IP: fe80::35d0:b39e:c3f7:e20f
+  "\xfe\x80\x00\x00\x00\x00\x00\x00\x35\xd0\xb3\x9e\xc3\xf7\xe2\x0f"
+  // Dest IP: ff02::1:2
+  "\xff\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x02"
+  // Payload (UDP, DHCPv6)
+  "\x02\x22\x02\x23\x00\x61\x56\x62\x01\x00"
+	"\x57\x03\x00\x08\x00\x02\x18\x9c\x00\x01\x00\x0e\x00\x01\x00\x01"
+	"\x15\xb7\xc4\xfa\x00\x1c\x25\xbc\xea\x83\x00\x03\x00\x0c\x1d\x00"
+	"\x22\xfb\x00\x00\x00\x00\x00\x00\x00\x00\x00\x27\x00\x0b\x00\x09"
+	"\x4c\x61\x70\x74\x6f\x70\x2d\x50\x43\x00\x10\x00\x0e\x00\x00\x01"
+	"\x37\x00\x08\x4d\x53\x46\x54\x20\x35\x2e\x30\x00\x06\x00\x08\x00"
+	"\x18\x00\x17\x00\x11\x00\x27";
+
+  CTX_SET(ctx, packet);
+
+  struct pair bpf_ret_value = {0, 0}; 
+  g_stream_map_lookup_value = &bpf_ret_value;
+
+  bpf_map_lookup_elem = bpf_map_lookup_elem_stream_mock_v6;
+  struct flowv6_keys *key = &g_stream_map_v6_lookup_keys;
+
+  int result = xdp_loadfilter(ctx);
+  assert(result == XDP_DROP);
+
+  assert(key->ip_proto == 0);
+  assert(memcmp(key->src, "\xfe\x80\x00\x00\x00\x00\x00\x00\x35\xd0\xb3\x9e\xc3\xf7\xe2\x0f", 16) == 0);
+  assert(memcmp(key->dst, "\xff\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x02", 16) == 0);
+  assert(key->port16[0] == 0x2202);
+  assert(key->port16[1] == 0x2302);
+  assert(key->ip_proto == 0);
+  assert(key->vlan0 == 0);
+  assert(key->vlan1 == 0);
+
+#ifdef DEBUG
+  // Thanks, copilot! (Also, too many args for DPRINTF.)
+  printf("key->ip_proto: %d, key->src: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x, key->dst: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x, key->port16[0]: %x, key->port16[1]: %x, key->vlan0: %x, key->vlan1: %x\n",
+          key->ip_proto,
+          ntohs(key->src[0] & 0xffff), ntohs((key->src[0] >> 16) & 0xffff), ntohs(key->src[1] & 0xffff), ntohs((key->src[1] >> 16) & 0xffff),
+          ntohs(key->src[2] & 0xffff), ntohs((key->src[2] >> 16) & 0xffff), ntohs(key->src[3] & 0xffff), ntohs((key->src[3] >> 16) & 0xffff),
+          ntohs(key->dst[0] & 0xffff), ntohs((key->dst[0] >> 16) & 0xffff), ntohs(key->dst[1] & 0xffff), ntohs((key->dst[1] >> 16) & 0xffff),
+          ntohs(key->dst[2] & 0xffff), ntohs((key->dst[2] >> 16) & 0xffff), ntohs(key->dst[3] & 0xffff), ntohs((key->dst[3] >> 16) & 0xffff),
+          ntohs(key->port16[0]), ntohs(key->port16[1]), key->vlan0, key->vlan1);
+#endif
+
+  // Not necessary right now, but will probably save me a headache later.
+  bpf_map_lookup_elem = bpf_map_lookup_elem_stream_mock_v4;
+}
+
+int main() {
+  setup_mocks();
+  bpf_map_lookup_elem = bpf_map_lookup_elem_stream_mock_v4;
+
+  // And our fake 32-bit addressable environment...
+  struct xdp_md ctx;
+  g_TopOfStack = HIGH32(&ctx);
+
+  TEST(ipv4_match);
+  TEST(gre_match);
+  TEST(IEEE8021ah_packet_vlan);
+  TEST(no_match);
+  TEST(ipv6);
+
+  return 0;
+}

--- a/ebpf/xdp_common.h
+++ b/ebpf/xdp_common.h
@@ -65,10 +65,6 @@
 
 #define LINUX_VERSION_CODE 263682
 
-static INLINE __u16 ntohs(__u16 val) {
-    return ((val & 0xff00) >> 8) + ((val & 0x00ff) << 8);
-}
-
 #ifdef DEBUG
 static void INLINE trace_ipv4(__u32 ip) {
     DPRINTF("%d.%d.<next line>\n", (ip & 0x000000ff), (ip & 0x0000ff00) >> 8);

--- a/ebpf/xdp_common.h
+++ b/ebpf/xdp_common.h
@@ -1,0 +1,147 @@
+/*
+ * Code that's common to multiple XDP programs. Duh.
+ */
+
+#ifndef _XDP_COMMON_H
+#define _XDP_COMMON_H
+
+#define KBUILD_MODNAME "foo"
+#include <stddef.h>
+#include <linux/bpf.h>
+
+#include <linux/in.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <linux/if_vlan.h>
+/* Workaround to avoid the need of 32bit headers */
+#define _LINUX_IF_H
+#define IFNAMSIZ 16
+#include <linux/if_tunnel.h>
+#include <linux/ip.h>
+#include <linux/ipv6.h>
+#include <linux/tcp.h>
+#include <linux/udp.h>
+#include "bpf_helpers.h"
+#include "network_headers.h"
+
+#ifdef DEBUG
+    #if DEBUG == 0
+    #undef DEBUG
+    #endif
+#else
+/* #define DEBUG 1 */
+#endif
+
+/* Both are required in order to ensure *everything* is inlined.  The kernel version that 
+ * we're using doesn't support calling functions in XDP, so it must appear as a single function.
+ * Kernel 4.16+ support function calls:
+ * https://stackoverflow.com/questions/70529753/clang-bpf-attribute-always-inline-does-not-working
+ */
+#define INLINE __always_inline __attribute__((always_inline))
+
+#ifdef DEBUG
+#define DPRINTF(fmt_str, args...) { \
+    char fmt[] = fmt_str; \
+    bpf_trace_printk(fmt, sizeof(fmt), args); \
+}
+#else
+#define DPRINTF(fmt_str, args...)
+#endif
+
+#define DPRINTF_ALWAYS(fmt_str, args...) \
+    { \
+        char fmt[] = fmt_str; \
+        bpf_trace_printk(fmt, sizeof(fmt), args); \
+    }
+
+/* The ifndef's around CTX_GET_*() allow the UT's to override them */
+#ifndef CTX_GET_DATA
+#define CTX_GET_DATA(ctx) (void*)(long)ctx->data
+#endif
+
+#ifndef CTX_GET_DATA_END
+#define CTX_GET_DATA_END(ctx) (void*)(long)ctx->data_end
+#endif
+
+#define LINUX_VERSION_CODE 263682
+
+static INLINE __u16 ntohs(__u16 val) {
+    return ((val & 0xff00) >> 8) + ((val & 0x00ff) << 8);
+}
+
+#ifdef DEBUG
+static void INLINE trace_ipv4(__u32 ip) {
+    DPRINTF("%d.%d.<next line>\n", (ip & 0x000000ff), (ip & 0x0000ff00) >> 8);
+    DPRINTF("%d.%d\n", (ip & 0x00ff0000) >> 16, (ip & 0xff000000) >> 24);
+}
+
+/* 
+ * Trace the tuple char-by-char for comparision with bpftool ouptput.
+ * Output is spread over multiple lines due to the limited number of args to
+ * bpf_trace_printk.
+ * 
+ * Unfortunately, the version of bpf_trace_printk that we're using doesn't seem
+ * to support %x, so hex conversion is left as an exercise for the user.
+ */
+static void trace_bytes(void *data, __u16 len) {
+    __u16 i = 0;
+    for (; i + 3 < len; i += 3) {
+        /* Three seems to be the most args we can pass to bpf_trace_printk. */
+        DPRINTF("%d %d %d\n", *((unsigned char*)data + i), *((unsigned char*)data + i + 1), *((unsigned char*)data + i + 2));
+    }
+
+    /* Get the remaining few bytes, if not evenly divisible by 3. */
+    for (; i < len; i++) {
+        DPRINTF("%d\n", *((unsigned char*)data + i));
+    }
+}
+#else
+#define trace_ipv4(ip)
+#define trace_bytes(data, len)
+#endif
+
+static INLINE int get_sport(void *trans_data, void *data_end, __u8 protocol)
+{
+    struct tcphdr *th;
+    struct udphdr *uh;
+
+    switch (protocol) {
+        case IPPROTO_TCP:
+            th = (struct tcphdr *)trans_data;
+            if ((void *)(th + 1) > data_end) {
+                return -1;
+            }
+            return th->source;
+        case IPPROTO_UDP:
+            uh = (struct udphdr *)trans_data;
+            if ((void *)(uh + 1) > data_end) {
+                return -1;
+            }
+            return uh->source;
+        default:
+            return 0;
+    }
+}
+
+static INLINE int get_dport(void *trans_data, void *data_end, __u8 protocol)
+{
+    struct tcphdr *th;
+    struct udphdr *uh;
+
+    switch (protocol) {
+        case IPPROTO_TCP:
+            th = (struct tcphdr *)trans_data;
+            if ((void *)(th + 1) > data_end)
+                return -1;
+            return th->dest;
+        case IPPROTO_UDP:
+            uh = (struct udphdr *)trans_data;
+            if ((void *)(uh + 1) > data_end)
+                return -1;
+            return uh->dest;
+        default:
+            return 0;
+    }
+}
+
+#endif /* _XDP_COMMON_H */

--- a/ebpf/xdp_lb.c
+++ b/ebpf/xdp_lb.c
@@ -34,12 +34,18 @@
 #include "bpf_helpers.h"
 #include "hash_func01.h"
 #include "network_headers.h"
+#include "xdp_common.h"
 
 #ifdef ENABLE_EAST_WEST_FILTER
 #include "east_west_filter.h"
 #endif
 
+#ifdef ENABLE_STREAM_FILTER
+#include "xdp_stream_filter_common.h"
+#endif
+
 #ifndef DEBUG
+/* #define DEBUG 1 */
 #define DEBUG 0
 #endif
 
@@ -50,36 +56,6 @@
 #define GRE_KEY_SIZE    (4)
 #define GRE_SEQ_SIZE    (4)
 #define GRE_ERSPAN_TYPE_II_HEADER_SIZE (8)
-
-/* Both are required in order to ensure *everything* is inlined.  The kernel version that
- * we're using doesn't support calling functions in XDP, so it must appear as a single function.
- * Kernel 4.16+ support function calls:
- * https://stackoverflow.com/questions/70529753/clang-bpf-attribute-always-inline-does-not-working
- */
-#define INLINE __always_inline __attribute__((always_inline))
-
-#define DPRINTF(fmt_str, args...) \
-    if (DEBUG) { \
-        char fmt[] = fmt_str; \
-        bpf_trace_printk(fmt, sizeof(fmt), args); \
-    }
-
-#define DPRINTF_ALWAYS(fmt_str, args...) \
-    { \
-        char fmt[] = fmt_str; \
-        bpf_trace_printk(fmt, sizeof(fmt), args); \
-    }
-
-/* The ifndef's around CTX_GET_*() allow the UT's to override them */
-#ifndef CTX_GET_DATA
-#define CTX_GET_DATA(ctx) (void*)(long)ctx->data
-#endif
-
-#ifndef CTX_GET_DATA_END
-#define CTX_GET_DATA_END(ctx) (void*)(long)ctx->data_end
-#endif
-
-#define LINUX_VERSION_CODE 263682
 
 /* Hashing initval */
 #define INITVAL 15485863
@@ -109,55 +85,7 @@ struct bpf_map_def SEC("maps") cpus_count = {
     .max_entries	= 1,
 };
 
-static INLINE __u16 ntohs(__u16 val) {
-    return ((val & 0xff00) >> 8) + ((val & 0x00ff) << 8);
-}
-
-static INLINE int get_sport(void *trans_data, void *data_end, __u8 protocol)
-{
-    struct tcphdr *th;
-    struct udphdr *uh;
-
-    switch (protocol) {
-        case IPPROTO_TCP:
-            th = (struct tcphdr *)trans_data;
-            if ((void *)(th + 1) > data_end) {
-                return -1;
-            }
-            return th->source;
-        case IPPROTO_UDP:
-            uh = (struct udphdr *)trans_data;
-            if ((void *)(uh + 1) > data_end) {
-                return -1;
-            }
-            return uh->source;
-        default:
-            return 0;
-    }
-}
-
-static INLINE int get_dport(void *trans_data, void *data_end, __u8 protocol)
-{
-    struct tcphdr *th;
-    struct udphdr *uh;
-
-    switch (protocol) {
-        case IPPROTO_TCP:
-            th = (struct tcphdr *)trans_data;
-            if ((void *)(th + 1) > data_end)
-                return -1;
-            return th->dest;
-        case IPPROTO_UDP:
-            uh = (struct udphdr *)trans_data;
-            if ((void *)(uh + 1) > data_end)
-                return -1;
-            return uh->dest;
-        default:
-            return 0;
-    }
-}
-
-static int INLINE hash_ipv4(void *data, void *data_end)
+static int INLINE hash_ipv4(struct xdp_md *ctx, void *data, void *data_end, __u16 vlan0, __u16 vlan1)
 {
     DPRINTF("hash_ipv4 %d\n", (int)(data_end - data));
 
@@ -192,6 +120,12 @@ static int INLINE hash_ipv4(void *data, void *data_end)
     DPRINTF("Flow proto  %d id %d\n", iph->protocol, iph->id);
     DPRINTF("     src %x:%d\n", iph->saddr, ntohs(sport));
     DPRINTF("     dst %x:%d\n", iph->daddr, ntohs(dport));
+
+#ifdef ENABLE_STREAM_FILTER
+    if (stream_filter_ipv4(ctx, iph, data, data_end, sport, dport, vlan0, vlan1) == XDP_DROP) {
+        return XDP_DROP;
+    }
+#endif
 
      __u32 cpu_hash;
      __u64 cpu_hash_input = 0;
@@ -239,7 +173,7 @@ static int INLINE sort128(__u64 *source, __u64 *dest)
     return (source[0] < dest[0]) | ((source[0] == dest[0]) & (source[1] < dest[1]));
 }
 
-static int INLINE hash_ipv6(void *data, void *data_end)
+static int INLINE hash_ipv6(struct xdp_md *ctx, void *data, void *data_end, __u16 vlan0, __u16 vlan1)
 {
     struct ipv6hdr *ip6h = data;
     if ((void *)(ip6h + 1) > data_end) {
@@ -270,6 +204,12 @@ static int INLINE hash_ipv6(void *data, void *data_end)
 
     __u64 ip_hash_input;
     __u32 cpu_hash;
+
+#ifdef ENABLE_STREAM_FILTER
+    if (stream_filter_ipv6(ctx, ip6h, data, data_end, sport, dport, vlan0, vlan1) == XDP_DROP) {
+        return XDP_DROP;
+    }
+#endif
 
     /*
      * IPV6 addresses are 128 bits, commonly expressed as a series of up to
@@ -403,9 +343,9 @@ static int INLINE filter_gre(struct xdp_md *ctx, void *data, __u64 nh_off, void 
     }
 
     if (proto == __constant_htons(ETH_P_IP)) {
-        return hash_ipv4(data + nh_off, data_end);
+        return hash_ipv4(ctx, data + nh_off, data_end, 0, 0);
     } else if (proto == __constant_htons(ETH_P_IPV6)) {
-        return hash_ipv6(data + nh_off, data_end);
+        return hash_ipv6(ctx, data + nh_off, data_end, 0, 0);
     } else {
         /* This packet isn't IPV4 or IPV6... it's likely still a legit ether type, but we intentionally
          * keep the packet handling light here, so even though we don't understand it, return it to the
@@ -417,7 +357,7 @@ static int INLINE filter_gre(struct xdp_md *ctx, void *data, __u64 nh_off, void 
     }
 }
 
-static int INLINE filter_ipv4(struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end)
+static int INLINE filter_ipv4(struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end, __u16 vlan0, __u16 vlan1)
 {
     struct iphdr *iph = data + nh_off;
     if ((void *)(iph + 1) > data_end) {
@@ -427,70 +367,18 @@ static int INLINE filter_ipv4(struct xdp_md *ctx, void *data, __u64 nh_off, void
     if (iph->protocol == IPPROTO_GRE) {
         return filter_gre(ctx, data, nh_off, data_end);
     }
-    return hash_ipv4(data + nh_off, data_end);
+
+    return hash_ipv4(ctx, data + nh_off, data_end, vlan0, vlan1);
 }
 
-static int INLINE filter_ipv6(struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end)
+static int INLINE filter_ipv6(struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end, __u16 vlan0, __u16 vlan1)
 {
     struct ipv6hdr *ip6h = data + nh_off;
-    return hash_ipv6((void *)ip6h, data_end);
+    return hash_ipv6(ctx, (void *)ip6h, data_end, vlan0, vlan1);
 }
 
-int SEC("xdp") xdp_loadfilter(struct xdp_md *ctx)
-{
-    void *data_end = CTX_GET_DATA_END(ctx);
-    void *data = CTX_GET_DATA(ctx);
-    struct ethhdr *eth = data;
-    __u16 h_proto;
-    __u64 nh_off;
-
-    DPRINTF("Packet %d len\n", (int)(data_end - data));
-
-    nh_off = sizeof(*eth);
-    if (data + nh_off > data_end) {
-        return XDP_PASS;
-    }
-
-    h_proto = eth->h_proto;
-
-    if (h_proto == __constant_htons(ETH_P_8021Q) || h_proto == __constant_htons(ETH_P_8021AD)) {
-        struct vlan_hdr *vhdr;
-
-        vhdr = data + nh_off;
-        nh_off += sizeof(struct vlan_hdr);
-        if (data + nh_off > data_end)
-            return XDP_PASS;
-        h_proto = vhdr->h_vlan_encapsulated_proto;
-    }
-    if (h_proto == __constant_htons(0x88e7)) {
-        IEEE8021ahHdr *hdr;
-
-        hdr = data + nh_off;
-        nh_off += sizeof(IEEE8021ahHdr);
-        if (data + nh_off > data_end)
-            return XDP_PASS;
-
-        h_proto = hdr->type;
-    }
-    if (h_proto == __constant_htons(ETH_P_8021Q) || h_proto == __constant_htons(ETH_P_8021AD)) {
-        struct vlan_hdr *vhdr;
-
-        vhdr = data + nh_off;
-        nh_off += sizeof(struct vlan_hdr);
-        if (data + nh_off > data_end)
-            return XDP_PASS;
-        h_proto = vhdr->h_vlan_encapsulated_proto;
-    }
-
-    if (h_proto == __constant_htons(ETH_P_IP)) {
-        return filter_ipv4(ctx, data, nh_off, data_end);
-    }
-    else if (h_proto == __constant_htons(ETH_P_IPV6)) {
-        return filter_ipv6(ctx, data, nh_off, data_end);
-    }
-
-    return XDP_PASS;
-}
+/* xdp_loadfilter() implementation */
+#include "xdp_load_filter.h"
 
 char __license[] SEC("license") = "GPL";
 

--- a/ebpf/xdp_lb.c
+++ b/ebpf/xdp_lb.c
@@ -118,8 +118,8 @@ static int INLINE hash_ipv4(struct xdp_md *ctx, void *data, void *data_end, __u1
     }
 
     DPRINTF("Flow proto  %d id %d\n", iph->protocol, iph->id);
-    DPRINTF("     src %x:%d\n", iph->saddr, ntohs(sport));
-    DPRINTF("     dst %x:%d\n", iph->daddr, ntohs(dport));
+    DPRINTF("     src %x:%d\n", iph->saddr, __constant_htons(sport));
+    DPRINTF("     dst %x:%d\n", iph->daddr, __constant_htons(dport));
 
 #ifdef ENABLE_STREAM_FILTER
     if (stream_filter_ipv4(ctx, iph, data, data_end, sport, dport, vlan0, vlan1) == XDP_DROP) {
@@ -352,7 +352,7 @@ static int INLINE filter_gre(struct xdp_md *ctx, void *data, __u64 nh_off, void 
          * network stack (we've already advanced past the GRE/ERSPAN headers to the encapsulated ethernet
          * frame, so chances are the linux stack, and suricata, know what to do with it)
          */
-        DPRINTF("GRE unknown inner proto %d id %d\n", ntohs(proto), ntohs(pkt_id));
+        DPRINTF("GRE unknown inner proto %d id %d\n", __constant_htons(proto), __constant_htons(pkt_id));
         return XDP_PASS;
     }
 }

--- a/ebpf/xdp_lb_ew_stream.c
+++ b/ebpf/xdp_lb_ew_stream.c
@@ -1,0 +1,4 @@
+
+#define ENABLE_STREAM_FILTER
+#define ENABLE_EAST_WEST_FILTER
+#include "xdp_lb.c"

--- a/ebpf/xdp_lb_stream.c
+++ b/ebpf/xdp_lb_stream.c
@@ -1,0 +1,2 @@
+#define ENABLE_STREAM_FILTER
+#include "xdp_lb.c"

--- a/ebpf/xdp_load_filter.h
+++ b/ebpf/xdp_load_filter.h
@@ -50,7 +50,7 @@ int SEC("xdp") xdp_loadfilter(struct xdp_md *ctx)
             return XDP_PASS;
 
         h_proto = hdr->type;
-        DPRINTF("802.1ah next header %x\n", ntohs(h_proto));
+        DPRINTF("802.1ah next header %x\n", __constant_htons(h_proto));
     }
     if (h_proto == __constant_htons(ETH_P_8021Q) || h_proto == __constant_htons(ETH_P_8021AD)) {
         struct vlan_hdr *vhdr;

--- a/ebpf/xdp_load_filter.h
+++ b/ebpf/xdp_load_filter.h
@@ -1,0 +1,77 @@
+/* #include at the end of an XDP filter implementation, after filter_ip4 and
+ * filter_ipb6 have been defined.
+ */
+
+#ifndef _XDP_LOAD_FILTER_H
+#define _XDP_LOAD_FILTER_H
+
+/* Keeps VSCode JIT/intellisense happy. (It has an include guard.) */
+#include "xdp_common.h"
+
+int SEC("xdp") xdp_loadfilter(struct xdp_md *ctx)
+{
+    void *data_end = CTX_GET_DATA_END(ctx);
+    void *data = CTX_GET_DATA(ctx);
+    struct ethhdr *eth = data;
+    __u16 h_proto;
+    __u64 nh_off;
+
+    /* Used by the stream filter look up flows. */
+    __u16 vlan0 = 0;
+    __u16 vlan1 = 0;
+
+    DPRINTF("Packet %d len\n", (int)(data_end - data));
+
+    nh_off = sizeof(*eth);
+    if (data + nh_off > data_end) {
+        return XDP_PASS;
+    }
+
+    h_proto = eth->h_proto;
+
+    if (h_proto == __constant_htons(ETH_P_8021Q) || h_proto == __constant_htons(ETH_P_8021AD)) {
+        struct vlan_hdr *vhdr;
+
+        vhdr = data + nh_off;
+        nh_off += sizeof(struct vlan_hdr);
+        if (data + nh_off > data_end)
+            return XDP_PASS;
+        h_proto = vhdr->h_vlan_encapsulated_proto;
+        vlan0 = vhdr->h_vlan_TCI & 0x0fff;
+        DPRINTF("nh_off %x vhdr->h_vlan_TCI %x\n", nh_off, vhdr->h_vlan_TCI);
+        DPRINTF("vlan0 %x\n", vlan0);
+    }
+    if (h_proto == __constant_htons(0x88e7)) {
+        IEEE8021ahHdr *hdr;
+
+        hdr = data + nh_off;
+        nh_off += sizeof(IEEE8021ahHdr);
+        if (data + nh_off > data_end)
+            return XDP_PASS;
+
+        h_proto = hdr->type;
+        DPRINTF("802.1ah next header %x\n", ntohs(h_proto));
+    }
+    if (h_proto == __constant_htons(ETH_P_8021Q) || h_proto == __constant_htons(ETH_P_8021AD)) {
+        struct vlan_hdr *vhdr;
+
+        vhdr = data + nh_off;
+        nh_off += sizeof(struct vlan_hdr);
+        if (data + nh_off > data_end)
+            return XDP_PASS;
+        h_proto = vhdr->h_vlan_encapsulated_proto;
+        vlan1 = vhdr->h_vlan_TCI & 0x0fff;
+        DPRINTF("vlan1 %x\n", vlan1);
+    }
+
+    if (h_proto == __constant_htons(ETH_P_IP)) {
+        return filter_ipv4(ctx, data, nh_off, data_end, vlan0, vlan1);
+    }
+    else if (h_proto == __constant_htons(ETH_P_IPV6)) {
+        return filter_ipv6(ctx, data, nh_off, data_end, vlan0, vlan1);
+    }
+
+    return XDP_PASS;
+}
+
+#endif /* _XDP_LOAD_FILTER_H */

--- a/ebpf/xdp_stream_filter.c
+++ b/ebpf/xdp_stream_filter.c
@@ -1,0 +1,57 @@
+/* Standalone stream filter implementation. */
+
+#include "xdp_common.h"
+
+/* Implementation of the stream filter functions, which are also used by xdp_lb.c. */
+#include "xdp_stream_filter_common.h"
+
+static int INLINE filter_ipv4(struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end, __u16 vlan0, __u16 vlan1)
+{
+    int sport;
+    int dport;
+
+    struct iphdr *iph = data + nh_off;
+    if ((void *)(iph + 1) > data_end) {
+        DPRINTF("Ignoring packet. iph: %d, data_end: %d\n", iph, data_end);
+        return XDP_PASS;
+    }
+
+    dport = get_dport(iph + 1, data_end, iph->protocol);
+    if (dport == -1)
+        return XDP_PASS;
+
+    sport = get_sport(iph + 1, data_end, iph->protocol);
+    if (sport == -1)
+        return XDP_PASS;
+
+
+    return stream_filter_ipv4(ctx, iph, data, data_end, sport, dport, vlan0, vlan1);
+}
+
+static int INLINE filter_ipv6(struct xdp_md *ctx, void *data, __u64 nh_off, void *data_end, __u16 vlan0, __u16 vlan1)
+{
+    int sport;
+    int dport;
+
+    struct ipv6hdr *ip6h = data + nh_off;
+    if ((void *)(ip6h + 1) > data_end) {
+        DPRINTF("Ignoring packet. iph: %d, data_end: %d\n", ip6h, data_end);
+        return XDP_PASS;
+    }
+
+    dport = get_dport(ip6h + 1, data_end, ip6h->nexthdr);
+    if (dport == -1)
+        return XDP_PASS;
+
+    sport = get_sport(ip6h + 1, data_end, ip6h->nexthdr);
+    if (sport == -1)
+        return XDP_PASS;
+
+    return stream_filter_ipv6(ctx, ip6h, data, data_end, sport, dport, vlan0, vlan1);
+}
+
+#include "xdp_load_filter.h"
+
+char __license[] SEC("license") = "GPL";
+
+__u32 __version SEC("version") = LINUX_VERSION_CODE;

--- a/ebpf/xdp_stream_filter_common.h
+++ b/ebpf/xdp_stream_filter_common.h
@@ -1,0 +1,153 @@
+/*
+ * Stream filter code that's used both in the standalone XDP stream filter
+ * (which is handy for debugging) and in xdp_lb.
+ */
+
+#ifndef _XDP_STREAM_FILTER_COMMON_H
+#define _XDP_STREAM_FILTER_COMMON_H
+
+#include "xdp_common.h"
+
+
+struct flowv4_keys {
+    __u32 src;
+    __u32 dst;
+    union {
+        __u32 ports;
+        __u16 port16[2];
+    };
+    __u8 ip_proto:1;
+    __u16 vlan0:15;
+    __u16 vlan1;
+};
+
+struct flowv6_keys {
+    __u32 src[4];
+    __u32 dst[4];
+    union {
+        __u32 ports;
+        __u16 port16[2];
+    };
+    __u8 ip_proto:1;
+    __u16 vlan0:15;
+    __u16 vlan1;
+};
+
+struct pair {
+    __u64 packets;
+    __u64 bytes;
+};
+
+struct bpf_map_def SEC("maps") flow_table_v4 = {
+    .type = BPF_MAP_TYPE_PERCPU_HASH,
+    .key_size = sizeof(struct flowv4_keys),
+    .value_size = sizeof(struct pair),
+    .max_entries = 32768,
+};
+
+struct bpf_map_def SEC("maps") flow_table_v6 = {
+    .type = BPF_MAP_TYPE_PERCPU_HASH,
+    .key_size = sizeof(struct flowv6_keys),
+    .value_size = sizeof(struct pair),
+    .max_entries = 32768,
+};
+
+
+static int INLINE stream_filter_ipv4(struct xdp_md *ctx, struct iphdr *iph, void *data, void *data_end, __u16 sport, __u16 dport, __u16 vlan0, __u16 vlan1)
+{
+    struct flowv4_keys tuple;
+    struct pair *value;
+
+    /* 
+     * This code assumes basic sanity checks were performed by the caller. 
+     * IE: if ((void *)(iph + 1) > data_end) {
+     */
+
+    if (iph->protocol == IPPROTO_TCP) {
+        tuple.ip_proto = 1;
+    } else {
+        tuple.ip_proto = 0;
+    }
+    tuple.src = iph->saddr;
+    tuple.dst = iph->daddr;
+
+    tuple.port16[0] = (__u16)sport;
+    tuple.port16[1] = (__u16)dport;
+
+    tuple.vlan0 = vlan0;
+    tuple.vlan1 = vlan1;
+
+    value = (struct pair*)bpf_map_lookup_elem(&flow_table_v4, &tuple);
+    if (value) {
+        /* Assumes per-cpu hash. */
+        value->packets++;
+        value->bytes += (__u64*)data_end - (__u64*)data;
+
+        DPRINTF("flow_table_v4 MATCH! Stream packets: %d, size: %d\n", value->packets, value->bytes);
+
+        /* Drop the packets in mirroring mode. Internal tap mode TBD. Until 
+         * there is a means for this code to determine if we're in internal_tap
+         * mode, we'll assume 'mirroring'.
+         */
+        DPRINTF("Assuming mirroring mode. Packet DROPPED. %d -> %d\n", ntohs(tuple.port16[0]), ntohs(tuple.port16[1]));
+        return XDP_DROP;
+    } else {
+        DPRINTF("No entry in v4 table for %d -> %d\n", ntohs(tuple.port16[0]), ntohs(tuple.port16[1]));
+        trace_ipv4(tuple.src);
+        trace_ipv4(tuple.dst);
+
+        /* 
+         * Trace the tuple bytes for comparision with bpftool ouptput.
+         *
+         * bpftool command line: 
+         *  sudo ./bpftool --pretty map dump name flow_table_v4
+         * 
+         * For Focal, get bpftool here: https://github.com/libbpf/bpftool/releases/tag/v7.2.0
+         * I was unsuccessful getting the version provided by apt to work, and according to
+         * Google that's a common problem.
+         */
+        DPRINTF("Tuple bytes follow (size: %d):\n", sizeof(struct flowv4_keys));
+        trace_bytes(&tuple, sizeof(struct flowv4_keys));
+    }
+
+    return XDP_PASS;
+}
+
+static int INLINE stream_filter_ipv6(struct xdp_md *ctx, struct ipv6hdr *ip6h, void *data, void *data_end, __u16 sport, __u16 dport, __u16 vlan0, __u16 vlan1)
+{
+    struct flowv6_keys tuple;
+    struct pair *value;
+
+    if ((void *)(ip6h + 1) > data_end)
+        return 0;
+    if (!((ip6h->nexthdr == IPPROTO_UDP) || (ip6h->nexthdr == IPPROTO_TCP)))
+        return XDP_PASS;
+
+    if (ip6h->nexthdr == IPPROTO_TCP) {
+        tuple.ip_proto = 1;
+    } else {
+        tuple.ip_proto = 0;
+    }
+    __builtin_memcpy(tuple.src, ip6h->saddr.s6_addr32, sizeof(tuple.src));
+    __builtin_memcpy(tuple.dst, ip6h->daddr.s6_addr32, sizeof(tuple.dst));
+    tuple.port16[0] = sport;
+    tuple.port16[1] = dport;
+
+    tuple.vlan0 = vlan0;
+    tuple.vlan1 = vlan1;
+
+    value = bpf_map_lookup_elem(&flow_table_v6, &tuple);
+    if (value) {
+        value->packets++;
+        value->bytes += data_end - data;
+        DPRINTF("flow_table_v6 MATCH! Assuming mirroring mode. Packet DROPPED. %d -> %d\n", ntohs(tuple.port16[0]), ntohs(tuple.port16[1]));
+        return XDP_DROP;
+    } else {
+        DPRINTF("No entry in v6 table for %d -> %d\n", ntohs(tuple.port16[0]), ntohs(tuple.port16[1]));
+    }
+
+    DPRINTF("stream_filter_ipv6, vlan0: %x, vlan1: %x\n", vlan0, vlan1);
+    return XDP_PASS;
+}
+
+#endif /* _XDP_STREAM_FILTER_COMMON_H */

--- a/ebpf/xdp_stream_filter_common.h
+++ b/ebpf/xdp_stream_filter_common.h
@@ -89,10 +89,10 @@ static int INLINE stream_filter_ipv4(struct xdp_md *ctx, struct iphdr *iph, void
          * there is a means for this code to determine if we're in internal_tap
          * mode, we'll assume 'mirroring'.
          */
-        DPRINTF("Assuming mirroring mode. Packet DROPPED. %d -> %d\n", ntohs(tuple.port16[0]), ntohs(tuple.port16[1]));
+        DPRINTF("Assuming mirroring mode. Packet DROPPED. %d -> %d\n", __constant_htons(tuple.port16[0]), __constant_htons(tuple.port16[1]));
         return XDP_DROP;
     } else {
-        DPRINTF("No entry in v4 table for %d -> %d\n", ntohs(tuple.port16[0]), ntohs(tuple.port16[1]));
+        DPRINTF("No entry in v4 table for %d -> %d\n", __constant_htons(tuple.port16[0]), __constant_htons(tuple.port16[1]));
         trace_ipv4(tuple.src);
         trace_ipv4(tuple.dst);
 
@@ -140,10 +140,10 @@ static int INLINE stream_filter_ipv6(struct xdp_md *ctx, struct ipv6hdr *ip6h, v
     if (value) {
         value->packets++;
         value->bytes += data_end - data;
-        DPRINTF("flow_table_v6 MATCH! Assuming mirroring mode. Packet DROPPED. %d -> %d\n", ntohs(tuple.port16[0]), ntohs(tuple.port16[1]));
+        DPRINTF("flow_table_v6 MATCH! Assuming mirroring mode. Packet DROPPED. %d -> %d\n", __constant_htons(tuple.port16[0]), __constant_htons(tuple.port16[1]));
         return XDP_DROP;
     } else {
-        DPRINTF("No entry in v6 table for %d -> %d\n", ntohs(tuple.port16[0]), ntohs(tuple.port16[1]));
+        DPRINTF("No entry in v6 table for %d -> %d\n", __constant_htons(tuple.port16[0]), __constant_htons(tuple.port16[1]));
     }
 
     DPRINTF("stream_filter_ipv6, vlan0: %x, vlan1: %x\n", vlan0, vlan1);


### PR DESCRIPTION
This PR includes the initial implementation of the XDP stream filter, which will drop traffic that has been bypassed by Suricata.

Once a flow hits a bypass rule in Suricata, it's added to "flow_table_v4", which is an ebpf table that allows flows to be looked up by tuple. The XDP stream filter checks the table when it gets new traffic; if the flow matches, then the traffic is dropped, which saves CPU cycles.

The XDP stream filter currently only works with mirroring deployments. Support for internal tap will be added later. An HLD is needed for that work.

Related PRs:
[Add the stream filter to the build (awn)](https://github.com/rtkwlf/awn/pull/67863)

Testing has been performed on both virtual and physical sensors. 

There are no plans to merge these changes back to the OSIF Suricata repo.


Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ ] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [ ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
