### PR TITLE
[SSC-826] fix socket ref count

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -876,6 +876,7 @@ static void AFPReleasePacketV3(Packet *p)
     if ((p->afp_v.copy_mode != AFP_COPY_MODE_NONE) && !PKT_IS_PSEUDOPKT(p)) {
         AFPWritePacket(p, TPACKET_V3);
     }
+    (void)AFPDerefSocket(p->afp_v.mpeer);
     PacketFreeOrRelease(p);
 }
 #endif


### PR DESCRIPTION
    [SSC-826] Fix AFPv3 socket ref count

    When using AFPacket V3, we we can use
    the packet data right from the ring (i.e.,
    zero-copy) we increment the socket ref
    to ensure the NIC is brought down while
    there are still references to the rx-queue.
    However, we don't ever decrement those
    references.
    This add a ref decrement upon freeing
    the packet.

[SSC-826]: https://arcticwolf.atlassian.net/browse/SSC-826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ