### PR TITLE
[SSC-3604] update unix socket log from info to debug

### DIFF
--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -593,7 +593,7 @@ static void UnixCommandRun(UnixCommand * this, UnixClient *client)
                     if (ret == -1) {
                         /* Signal was caught: just ignore it */
                         if (errno != EINTR) {
-                            SCLogInfo("Unix socket: lost connection with client");
+                            SCLogDebug("Unix socket: lost connection with client");
                             UnixCommandClose(this, client->fd);
                             return;
                         }


### PR DESCRIPTION
Currently, an Info-level log message is generated every time suricatasc disconnects from the interactive Unix socket:
```
<Info> - Unix socket: lost connection with client
```

Since this is expected behavior during normal interactive usage, logging it at the Info level is unnecessarily verbose.

This change lowers the log level from Info to Debug, so the message will only appear when debug logging is enabled. This helps reduce noise in standard log output while preserving visibility for troubleshooting when needed.
