### PR TITLE
AWN-39270-http-hostname-in-flow

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1726,6 +1726,11 @@ static int HTPCallbackRequestComplete(const htp_connp_t *connp, htp_tx_t *tx)
         SCReturnInt(HTP_STATUS_ERROR);
     }
 
+    /* Attach the hostname to the flow for inclusion in flow JSON log records */
+    if (hstate->f->http_hostname == NULL && htp_tx_request_hostname(tx) != NULL) {
+        hstate->f->http_hostname = bstr_util_strdup_to_c(htp_tx_request_hostname(tx));
+    }
+
     const uint64_t abs_right_edge =
             hstate->slice->offset + htp_connp_request_data_consumed(hstate->connp);
 
@@ -1873,10 +1878,6 @@ static int HTPCallbackRequestHeaderData(const htp_connp_t *connp, htp_tx_data_t 
     HtpState *hstate = htp_connp_user_data(connp);
     if (tx && htp_tx_flags(tx)) {
         HTPErrorCheckTxRequestFlags(hstate, tx);
-    }
-    /* Attach the hostname to the flow for inclusion in flow JSON log records */
-    if (hstate->f->http_hostname == NULL && htp_tx_request_hostname(tx) != NULL) {
-        hstate->f->http_hostname = bstr_util_strdup_to_c(htp_tx_request_hostname(tx));
     }
     return HTP_STATUS_OK;
 }

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -182,7 +182,7 @@ void EveAddAppProto(Flow *f, SCJsonBuilder *js)
     }
 
     /* Log the hostname for HTTP flows */
-    if (f->alproto == ALPROTO_HTTP && f->http_hostname != NULL) {
+    if ((f->alproto == ALPROTO_HTTP1 || f->alproto == ALPROTO_HTTP2) && f->http_hostname != NULL) {
         SCJbSetString(js, "hostname", f->http_hostname);
     }
 


### PR DESCRIPTION
Issue: host-name is not getting logged in HTTP flows

RCA: Suricata 6 used the C-based libhtp, which parsed headers incrementally and made the Host header (and thus the hostname) available as soon as it was parsed—often during the header data callback (HTPCallbackRequestHeaderData). Suricata 8 uses an in-tree Rust-based libhtp implementation. In this version, the hostname (request_hostname) is only set after all headers are fully parsed and processed, not during incremental header parsing. This means htp_tx_request_hostname(tx) will return NULL in HTPCallbackRequestHeaderData and only be available in later callbacks like HTPCallbackRequestComplete

Fix: Moved the updating hostname to HTPCallbackRequestComplete and also checking for ALPROTO_HTTP1 and ALPROTO_HTTP2 to identify HTTP flows as suricata8 distinguishes HTTP HTTP/1.x and HTTP/2

Test Done:
verified that hostname is getting logged in HTTP flows

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ ] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [ ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
