### PR TITLE
Fixes in suricata-awn to get  suricata-verify-8.0.3 working

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "suricata-verify"]
 path = suricata-verify
 url = git@github.com:rtkwlf/suricata-verify.git
-	branch = awn-suricata-verify-8.0.3
+branch = awn-suricata-verify-8.0.3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "suricata-verify"]
 path = suricata-verify
 url = git@github.com:rtkwlf/suricata-verify.git
-branch = awn-suricata-verify-6.0.17
+	branch = awn-suricata-verify-8.0.3

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2078,6 +2078,10 @@
                     "description":
                             "The exception policy(ies) triggered by the flow. Not logged if none was triggered"
                 },
+                "midstream": {
+                    "type": "boolean",
+                    "description": "Indicates if the flow was picked up midstream (not from the beginning)"
+                },
                 "pkts_toclient": {
                     "type": "integer",
                     "suricata": {
@@ -2223,6 +2227,10 @@
             "$comment":
                     "May change to sensor_name in the future, or become user configurable: https://redmine.openinfosecfoundation.org/issues/4919",
             "description": "the sensor-name, if configured"
+        },
+        "hostname": {
+            "type": "string",
+            "description": "HTTP hostname extracted from the flow, logged at event level"
         },
         "http": {
             "type": "object",
@@ -2426,6 +2434,34 @@
                 },
                 "xff": {
                     "type": "string"
+                },
+                "payload": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "sha256": {
+                            "type": "string",
+                            "description": "SHA256 hash of the HTTP payload"
+                        },
+                        "bytes-hashed": {
+                            "type": "integer",
+                            "description": "Number of bytes hashed for the payload"
+                        },
+                        "file-magic-type": {
+                            "type": "string",
+                            "description": "File type detected via magic/libmagic"
+                        },
+                        "file-magic-extra": {
+                            "type": "string",
+                            "description": "Additional file type information from magic/libmagic"
+                        }
+                    }
+                },
+                "request_total_length": {
+                    "type": "integer"
+                },
+                "response_total_length": {
+                    "type": "integer"
                 }
             }
         },
@@ -8199,6 +8235,12 @@
                     "type": "string"
                 },
                 "tcp_flags_ts": {
+                    "type": "string"
+                },
+                "tcp_init_flags_tc": {
+                    "type": "string"
+                },
+                "tcp_init_flags_ts": {
                     "type": "string"
                 },
                 "ts_gap": {

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -908,7 +908,8 @@ static int SCThresholdConfAddThresholdtype(char *rawstr, DetectEngineCtx *de_ctx
         goto error;
     }
 
-    pcre2_substring_free((PCRE2_UCHAR8 *)th_ip);
+    if (th_ip != NULL)
+        pcre2_substring_free((PCRE2_UCHAR8 *)th_ip);
     return 0;
 error:
     if (th_ip != NULL)


### PR DESCRIPTION


Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [ ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-  Update schema.json to support fields previously introduced by AWN, so that schema validation checks in suricata-verify pass successfully 
- Update the reference to suricata-verify submodule to point to the working 8.0.3 version of suricata-verify. 
- Fixes an issue in util-threshold-config.c which was causing a seg fault during threshold-config related tests.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
