### PR TITLE
SSC-8936-suricata8 crash during flow cleanup

### DIFF
--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -238,7 +238,14 @@ void FlowInitFromFlow(ThreadVars *tv, Flow* f, const Flow* old_f, const Packet* 
     // Copy only the direction bit, not all flags to avoid carrying over
     // app-layer state flags that prevent logging (AWN-78421)
     f->flags = old_f->flags & FLOW_DIR_REVERSED;
-
+    if (PacketIsIPv4(p)) {
+        f->flags |= FLOW_IPV4;
+    } else if (PacketIsIPv6(p)) {
+        f->flags |= FLOW_IPV6;
+    } else {
+        SCLogDebug("neither IPv4 or IPv6, weird");
+        DEBUG_VALIDATE_BUG_ON(1);
+    }
     f->flow_hash = old_f->flow_hash;
 
     //reset ttl and let it re-calculate it from packets in new flow.


### PR DESCRIPTION
RCA: For rolled over flow, the flow type is not copied and hence, the TCP pointer is not set and it causes null pointer exception

Fix: setting the flow type so that TCP pointer is correctly set depending on IPv4/IPv6

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
